### PR TITLE
feat(stellar): add classic asset issuer to TokenDataDoc (1.0.417)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xoxno/types",
-  "version": "1.0.417",
+  "version": "1.0.416",
   "description": "Shared types and utilities for XOXNO API.",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xoxno/types",
-  "version": "1.0.416",
+  "version": "1.0.417",
   "description": "Shared types and utilities for XOXNO API.",
   "exports": {
     ".": {

--- a/src/entities/token-data/token-data.doc.ts
+++ b/src/entities/token-data/token-data.doc.ts
@@ -63,6 +63,15 @@ class TokenDataDocBase {
   })
   stellarNetwork?: 'mainnet' | 'testnet';
 
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      'Issuer account (G…) of a Stellar classic asset. Absent for native XLM and pure-Soroban tokens. Lets clients build a changeTrust trustline without an on-chain name() lookup.',
+    example: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+  })
+  issuer?: string;
+
   constructor(props?: Partial<TokenDataDocBase>) {
     Object.assign(this, props);
   }


### PR DESCRIPTION
## What
Adds an optional `issuer?: string` to `TokenDataDocBase` — the classic-asset issuer (`G…` account) of a Stellar asset. Lands on both `TokenDataDoc` and `TokenDataDocWithBalance`. Bumps the package to **1.0.417**.

## Why
The xoxno-ui Stellar borrow/withdraw **trustline pre-check** needs `{code, issuer}` to build a `changeTrust` for an asset the wallet doesn't yet hold (e.g. a fresh wallet borrowing USDC). Today the UI falls back to an on-chain SAC `name()` simulate to recover the issuer. Exposing `issuer` on the token data removes that on-chain call (and its format assumption).

- Absent for native XLM and pure-Soroban tokens (presence of `issuer` == classic asset that needs a trustline).
- Additive + optional → zero impact on MVX / Sui consumers.

## Coordinated release
1. Publish `@xoxno/types@1.0.417` (this PR).
2. `xoxno-api` PR bumps its dep to 1.0.417 and persists/returns `issuer` (sync + `tokenInventory`).
3. Re-sync Stellar tokens to backfill `issuer` on existing docs.
4. xoxno-ui bumps `@xoxno/types` and reads `issuer`, dropping the `name()` fallback.

https://claude.ai/code/session_01BgKDnoZBk4sVaBC71rYPuu