### PR TITLE
feat(stellar): add swappable flag to TokenDataDoc

### DIFF
--- a/src/entities/token-data/token-data.doc.ts
+++ b/src/entities/token-data/token-data.doc.ts
@@ -72,6 +72,15 @@ class TokenDataDocBase {
   })
   issuer?: string;
 
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    description:
+      'Whether the token is swappable (present in a DEX/Soroswap token list). Lets the swap picker show only swappable tokens while other views use the full registry.',
+    example: true,
+  })
+  swappable?: boolean;
+
   constructor(props?: Partial<TokenDataDocBase>) {
     Object.assign(this, props);
   }


### PR DESCRIPTION
Adds optional `swappable?: boolean` to `TokenDataDocBase` — true when a token is present in a DEX/Soroswap token list. Lets the swap picker show only swappable tokens while lending/inventory views keep using the full registry.

Set by `xoxno-az-functions` (from the Soroswap source lists, preserved even when a token is also a lending market). Additive + optional → no impact on existing consumers.

Part of the swap-token cleanup: types → az-functions (tag) → api-v2 (bump) → xoxno-ui (swap list filters swappable).

https://claude.ai/code/session_01BgKDnoZBk4sVaBC71rYPuu